### PR TITLE
Get picture responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var Bot  = require('@kikinteractive/kik');
 var susi= require('./susi.js');
+var request = require("request");
 
 var bot = new Bot({
     username: process.env.KIK_BOT_USERNAME,
@@ -15,8 +16,36 @@ setInterval(function() {
 bot.updateBotConfiguration();
 
 bot.onTextMessage((message) => {
-    susi.ask(message.body,function (answer) {
-      message.reply(answer)
+	var chatID = message.chatId;
+	var Username;
+	bot.getUserProfile(message.from).then((user) => {
+		Username = user.username;
+	});
+
+
+    susi.ask(message.body,function (answer, type) {
+        if(type === "photo"){
+            request.post({
+                url: "https://api.kik.com/v1/message",
+                auth: {
+                    user: process.env.KIK_BOT_USERNAME,
+                    pass: process.env.API_KEY
+                },
+                json: {
+                    "messages": [
+                    {
+                        "chatId": chatID,
+                        "type": "picture",
+                        "to": Username,
+                        "picUrl": answer
+                    }
+                    ]
+                }
+            });
+        }
+        else {
+            message.reply(answer);
+        }
     })
 });
 

--- a/susi.js
+++ b/susi.js
@@ -1,8 +1,8 @@
 const request=require('request')
 const askSusi=function (query,cb) {
   request('https://api.susi.ai/susi/chat.json?q='+encodeURI(query), function (error, response, body) {
+    var data = JSON.parse(body);
     if (!error && response.statusCode == 200) {
-      var data = JSON.parse(body);
 		message = '';
 		if(data.answers[0].actions[1]){
 			if(data.answers[0].actions[1].type === 'rss'){
@@ -36,10 +36,10 @@ const askSusi=function (query,cb) {
 				message = data.answers[0].actions[0].expression;
 			}
 		} 
-      	cb(message); 
+      cb(message, data.answers[0].data[0].type); 
     }
     else {
-      cb('Oops, Looks like Susi is taking a break, She will be back soon')
+      cb('Oops, Looks like Susi is taking a break, She will be back soon', data.answers[0].data[0].type)
     }
   })
 }


### PR DESCRIPTION
Fixes #31 

Changes: Now whenever the response from SUSI server is a link to a picture, a POST request is made to https://api.kik.com/v1/message to send the picture to the user instead of the URL.

Screenshots for the change: 

Before -
<img width="250" alt="screen shot 2018-05-19 at 3 53 52 pm" src="https://user-images.githubusercontent.com/31174685/40267625-5005fc4a-5b7d-11e8-8309-b4a39404b4d1.jpg">

After -
<img width="250" alt="screen shot 2018-05-19 at 3 53 52 pm" src="https://user-images.githubusercontent.com/31174685/40268332-1a8c4bf8-5b89-11e8-94f4-1e00bf3a4dd8.jpg">
